### PR TITLE
BaseEntity: remote property was not usable.

### DIFF
--- a/lib/MilkCheck/Engine/BaseEntity.py
+++ b/lib/MilkCheck/Engine/BaseEntity.py
@@ -693,7 +693,8 @@ class BaseEntity(object):
         if self.target is None:
             self.target = entity.target
         self.mode = self.mode or entity.mode
-        self.remote = self.remote and entity.remote
+        if self.remote is None:
+            self.remote = entity.remote
         if self.desc is None:
             self.desc = entity.desc
         self.delay = self.delay or entity.delay


### PR DESCRIPTION
Before, we could set a remote property (Boolean) but it was rewriten
in BaseEntity's inherits_from with the result of a comparison of a
Boolean and a NoneType. Thus, we could only set remote to True, because
'False or None' evaluates to None, which is the default value.

Now, we can set the remote property to False and use the functionality
it unveils within ClusterShell.