### PR TITLE
.travis.yml: Enable timeout tests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,0 @@
-ignore:
-  - "tests/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
     - "echo -e '[Main]\\ndefault: local\\n[local]\\nmap: echo' > ~/.local/etc/clustershell/groups.conf"
 
 script:
-    - export PYTHONPATH=$PWD/lib/; nosetests --exe --all-modules -w tests -e test_mix_errors_timeout --with-coverage
+    - export PYTHONPATH=$PWD/lib/; nosetests --exe --all-modules -w tests --with-coverage
 
 # Push the results back to codecov
 after_success:


### PR DESCRIPTION
Now with commit  cd1b214d0d37ec277a48c750d3c065ea1275dff3, we don't need to make an exception on tests launched by travis.

.codecov.yml is then unuseful.