### PR TITLE
ActionTest.py: fix timeout test failling with 0.600 not between 0.6 a…

### DIFF
--- a/tests/MilkCheckTests/EngineTests/ActionTest.py
+++ b/tests/MilkCheckTests/EngineTests/ActionTest.py
@@ -246,8 +246,8 @@ class ActionTest(TestCase):
         service.run('start')
         self.assertEqual(action.tries, 3)
         self.assertEqual(action.status, TIMEOUT)
-        self.assertTrue(0.6 <= action.duration <= 0.8,
-                        "%.3f is not between 0.6 and 0.8" % action.duration)
+        self.assertTrue(0.59 <= action.duration <= 0.8,
+                        "%.3f is not between 0.59 and 0.8" % action.duration)
 
     def test_schedule(self):
         """Test behaviour method schedule"""


### PR DESCRIPTION
This commit workaround a ClusterShell precsion issue when using too
small values on timers.
https://github.com/cea-hpc/clustershell/issues/399

Change-Id: I88157e090b5cb94ff7fb5a1648dedbf3dd32e88f