### PR TITLE
Fix Already define exception when using --var="foo=bar"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
 
 install:

--- a/lib/MilkCheck/Engine/BaseEntity.py
+++ b/lib/MilkCheck/Engine/BaseEntity.py
@@ -322,6 +322,15 @@ class BaseEntity(object):
         if varname in self.variables:
             del self.variables[varname]
 
+    def update_var(self, varname, value):
+        """ Update existing variable """
+        # Debugging
+        logger = logging.getLogger('milkcheck')
+        logger.info("Variable '%s' updating '%s' (was '%s')",
+                    varname, value, self.variables[varname])
+        self.remove_var(varname)
+        self.add_var(varname, value)
+
     def update_target(self, nodeset, mode=None):
         '''Update the attribute target of an entity'''
         assert nodeset is not None

--- a/tests/MilkCheckTests/UITests/CliTest.py
+++ b/tests/MilkCheckTests/UITests/CliTest.py
@@ -1,5 +1,6 @@
-# Copyright CEA (2011-2017)
+# Copyright CEA (2011-2019)
 # Contributor: TATIBOUET Jeremie
+# Contributor: CEDEYN Aurelien
 #
 
 """
@@ -913,6 +914,7 @@ ServiceGroup                                                      [    OK   ]
         self._output_check(['warn', 'go', '-q'], RC_WARNING,
 """warn                                                              [ WARNING ]
 """)
+
     def test_custom_defines(self):
         '''Test command line output custom variables'''
         svc = Service('one')
@@ -922,6 +924,28 @@ ServiceGroup                                                      [    OK   ]
 """go one on localhost
  > /bin/echo bar
 one                                                               [    OK   ]
+""")
+
+    def test_overriding_defines(self):
+        """Test command line with overriden variables"""
+        tmpdir = tempfile.mkdtemp(prefix='test-mlk-')
+        tmpfile = tempfile.NamedTemporaryFile(suffix='.yaml', dir=tmpdir)
+        tmpfile.write(textwrap.dedent("""
+            variables:
+                foo: pub
+
+            services:
+              svc:
+                actions:
+                  start:
+                    cmd: echo %foo
+                    """))
+        tmpfile.flush()
+
+        self._output_check(['svc', 'start', '-v', '-c', tmpdir, '--define', 'foo=bar'], RC_OK,
+"""start svc on localhost
+ > echo bar
+svc                                                               [    OK   ]
 """)
 
 class CLIConfigDirTests(CLICommon):


### PR DESCRIPTION
This PR fixes :
$ milkcheck -c ~/devel/milkcheck-cedeyn/conf/test_variables status --var 'foo=bar'
[14:36:42] ERROR    -