### PR TITLE
Make tests output similar regardless nosetest or python version

### DIFF
--- a/lib/MilkCheck/ServiceManager.py
+++ b/lib/MilkCheck/ServiceManager.py
@@ -178,7 +178,7 @@ class ServiceManager(ServiceGroup):
         grph += "compound=true;\n"
         #grph += "node [shape=circle];\n"
         grph += "node [style=filled];\n"
-        for service in (services or self._subservices):
+        for service in (services or sorted(self._subservices.keys())):
             if not self._subservices[service].excluded(excluded):
                 grph += self._subservices[service].graph(excluded)
         grph += '}\n'

--- a/tests/MilkCheckTests/ServiceManagerTest.py
+++ b/tests/MilkCheckTests/ServiceManagerTest.py
@@ -247,10 +247,10 @@ node [style=filled];
 """digraph dependency {
 compound=true;
 node [style=filled];
-"E1" -> "D0";
-"E1" -> "D1";
 "D0";
 "D1";
+"E1" -> "D0";
+"E1" -> "D1";
 }
 """)
         self.assertEqual(manager.output_graph(excluded=['D0']),

--- a/tests/MilkCheckTests/UITests/CliTest.py
+++ b/tests/MilkCheckTests/UITests/CliTest.py
@@ -43,6 +43,7 @@ from MilkCheck.UI.OptionParser import InvalidOptionError
 from MilkCheckTests import setup_sshconfig, cleanup_sshconfig
 
 HOSTNAME = socket.gethostname().split('.')[0]
+PROGNAME = os.path.basename(sys.argv[0])
 
 class MyOutput(StringIO):
     ''' Class replacing stdout to manage output in nosetest '''
@@ -587,7 +588,7 @@ class CommandLineOutputTests(CLICommon):
     def test_command_output_help(self):
         '''Test command line help output'''
         self._output_check([], RC_OK,
-"""Usage: nosetests [options] [SERVICE...] ACTION
+"""Usage: {prog} [options] [SERVICE...] ACTION
 
 Options:
   --version             show program's version number and exit
@@ -618,7 +619,7 @@ Options:
     --nodeps            Do not run dependencies
     -t TAGS, --tags=TAGS
                         Run services matching these tags
-""")
+""".format(prog=PROGNAME))
 
     def test_command_output_checkconfig(self):
         '''Test command line output checking config'''
@@ -1280,7 +1281,7 @@ class CommandLineExceptionsOutputTests(CLICommon):
         self.manager.call_services = \
                 lambda services, action, conf=None: raiser(InvalidOptionError)
         self._output_check(['start'], RC_EXCEPTION,
-'''Usage: nosetests [options] [SERVICE...] ACTION
+'''Usage: {prog} [options] [SERVICE...] ACTION
 
 Options:
   --version             show program's version number and exit
@@ -1311,7 +1312,7 @@ Options:
     --nodeps            Do not run dependencies
     -t TAGS, --tags=TAGS
                         Run services matching these tags
-''',
+'''.format(prog=PROGNAME),
 '''[00:00:00] CRITICAL - Invalid options: 
 
 [00:00:00] CRITICAL - Invalid options: 

--- a/tests/MilkCheckTests/UITests/CliTest.py
+++ b/tests/MilkCheckTests/UITests/CliTest.py
@@ -314,9 +314,9 @@ nodeps: False
 report: no
 reverse_actions: ['stop']
 summary: False
-tags: set([])
+tags: {setoutput}
 verbosity: 5
-[I1]\r[I1]\r[I2]\r[I2]\r""")
+[I1]\r[I1]\r[I2]\r[I2]\r""".format(setoutput=str(set())))
 
     def test_excluded_node(self):
         '''Execute with a node exclusion (-vvv -x ...)'''
@@ -366,9 +366,9 @@ only_nodes: HOSTNAME
 report: no
 reverse_actions: ['stop']
 summary: False
-tags: set([])
+tags: {setoutput}
 verbosity: 5
-[I1]\r[I1]\r[I2]\r[I2]\r[S3]\r[S3]\r""")
+[I1]\r[I1]\r[I2]\r[I2]\r[S3]\r[S3]\r""".format(setoutput=str(set())))
 
     def test_execute_explicit_service(self):
         '''Execute a service from the CLI (-vvv -x ...)'''
@@ -450,9 +450,9 @@ nodeps: False
 report: no
 reverse_actions: ['stop']
 summary: False
-tags: set([])
+tags: {setoutput}
 verbosity: 5
-[I1]\r[I1]\r[I2]\r[I2]\r[S3]\r[S3]\r""")
+[I1]\r[I1]\r[I2]\r[I2]\r[S3]\r[S3]\r""".format(setoutput=str(set())))
 
     def test_multiple_services_reverse(self):
         """CLI reverse execute() with explicit services (S1 S3 -d)"""
@@ -481,9 +481,9 @@ nodeps: False
 report: no
 reverse_actions: ['stop']
 summary: False
-tags: set([])
+tags: {setoutput}
 verbosity: 5
-[S1]\r[S1]\r[S1]\r[S3]\r[S3]\r""")
+[S1]\r[S1]\r[S1]\r[S3]\r[S3]\r""".format(setoutput=str(set())))
 
     def test_overall_graph(self):
         """CLI execute() with whole graph (-v -x )"""
@@ -1361,9 +1361,9 @@ nodeps: False
 report: no
 reverse_actions: ['stop']
 summary: False
-tags: set([])
+tags: {setoutput}
 verbosity: 5
-''')
+'''.format(setoutput=str(set())))
 
 class ConsoleOutputTest(TestCase):
     '''Tests console output'''


### PR DESCRIPTION
progname, set() and graph output may change in tests depending on python or nosetest version.
This PR fixes this. 