### PR TITLE
.gitignore: ignore build and backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.pyc
+*~
+*.bak
+*.swp
+build/*


### PR DESCRIPTION
* Ignore root build/ directory (used by setup.py).
* Ignore backup files from editors