### PR TITLE
Action: get right fanout value when removing a task

### DIFF
--- a/lib/MilkCheck/Engine/Action.py
+++ b/lib/MilkCheck/Engine/Action.py
@@ -158,7 +158,7 @@ class ActionManager(object):
             if len(self.entities[fnt]) == 0:
                 del self.entities[fnt]
                 if self.entities:
-                    self.fanout = self.entities.keys()[0]
+                    self.fanout = sorted(self.entities.keys())[0]
                     self._master_task.set_info('fanout', self.fanout)
                 else:
                     self.fanout = None

--- a/tests/MilkCheckTests/EngineTests/ActionTest.py
+++ b/tests/MilkCheckTests/EngineTests/ActionTest.py
@@ -502,6 +502,7 @@ class ActionManagerTest(TestCase):
         task_manager.add_task(task2)
         task_manager.add_task(task3)
         task_manager.add_task(task4)
+        self.assertEqual(task_manager.fanout, 85)
         task_manager.remove_task(task2)
         self.assertEqual(task_manager.fanout, 85)
         task_manager.remove_task(task3)


### PR DESCRIPTION
When removing a task, the fanout value was taken randomly (depending on
a dict keys). Sorting entities keys fix this behaviour.