### PR TITLE
(#39) BaseEntity: Fix 'filter' propagation with service group

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2018-04-18 Aurelien Degremont  <aurelien.degremont@cea.fr>
+	* Fix 'filter' when using a service group (ticket #39)
+
 2019-07-10 Aurelien Cedeyn  <aurelien.cedeyn@cea.fr>
 	* Release: 1.2.2
 	* Fix variables override (PR #43)

--- a/lib/MilkCheck/Engine/BaseEntity.py
+++ b/lib/MilkCheck/Engine/BaseEntity.py
@@ -162,7 +162,7 @@ class Dependency(object):
 
     def filter_nodes(self, nodes):
         """Filter provided nodes to dependency target."""
-        if self.dep_type == FILTER:
+        if self.dep_type != REQUIRE_WEAK:
             self.target.filter_nodes(nodes)
 
     def is_weak(self):


### PR DESCRIPTION
When a service inside a service group has failed nodes
and another service depends on this group, with a 'filter'
dependency the failed nodes were not correctly propagated,
resulting on 'filter' not really applied.
This patch propagates the failed_nodes unconditionnaly.

Add more tests for this feature.

Closes #39.

Change-Id: I8d616352fad332ff45d94a3f0c5490002b9b68c7