### PR TITLE
Make inter-groups dependencies possible

### DIFF
--- a/lib/MilkCheck/Engine/ServiceGroup.py
+++ b/lib/MilkCheck/Engine/ServiceGroup.py
@@ -356,8 +356,8 @@ class ServiceGroup(Service):
                     self._subservices[subservice] = service
                     service.parent = self
 
-                    # Populate based on dict content
-                    service.fromdict(props)
+                    # Populate service variables present in YAML
+                    service.fromdict({'variables': props.get('variables', {})})
 
                     wrap.source = service
                     dep_mapping[subservice] = wrap
@@ -384,6 +384,13 @@ class ServiceGroup(Service):
                     service.add_dep(self._source, parent=False)
                 if not service.parents:
                     service.add_dep(self._sink)
+
+            # Build the sub-services from YAML, excluding already populated variables
+            for names, props in grpdict['services'].items():
+                for subservice in NodeSet(names):
+                    assert(subservice in self._subservices)
+                    props.pop('variables', None)
+                    self._subservices[subservice].fromdict(props)
 
         for subser in self.iter_subservices():
             subser.inherits_from(self)

--- a/lib/MilkCheck/Engine/ServiceGroup.py
+++ b/lib/MilkCheck/Engine/ServiceGroup.py
@@ -113,6 +113,12 @@ class ServiceGroup(Service):
         
     def search(self, name, reverse=False):
         """Look for a node through the overall graph"""
+        if "." in name:
+            _grp_name, _sub_name = name.split('.', 2)
+            _grp = self.search(_grp_name, reverse)
+            if isinstance(_grp, ServiceGroup) and _grp.has_subservice(_sub_name):
+                return _grp._subservices[_sub_name]
+
         target = None
         if reverse:
             target = self._sink.search(name, reverse)

--- a/lib/MilkCheck/Engine/ServiceGroup.py
+++ b/lib/MilkCheck/Engine/ServiceGroup.py
@@ -379,10 +379,12 @@ class ServiceGroup(Service):
                         wrap.deps[dtype] = [wrap.deps[dtype]]
 
                     for dep in wrap.deps[dtype]:
-                        if dep not in self._subservices:
+                        dep_obj = self.search(dep)
+                        if dep in self._subservices:
+                            dep_obj = self._subservices[dep]
+                        elif dep_obj is None:
                             raise UnknownDependencyError(dep)
-                        wrap.source.add_dep(self._subservices[dep],
-                                                         sgth=dtype.upper())
+                        wrap.source.add_dep(dep_obj, sgth=dtype.upper())
 
             # Bind subgraph to the service group
             for service in self.iter_subservices():

--- a/tests/MilkCheckTests/EngineTests/ServiceGroupTest.py
+++ b/tests/MilkCheckTests/EngineTests/ServiceGroupTest.py
@@ -108,6 +108,52 @@ class ServiceGroupTest(TestCase):
         self.assertTrue(eser1.search('E3'))
         self.assertFalse(group.search('E0'))
 
+    def test_search_node_graph_with_dot(self):
+        """Test search node in a graph trough a ServiceGroup"""
+        group = ServiceGroup('GROUP')
+        ser1 = Service('I1.a')
+        ser2 = Service('I2')
+        eser1 = Service('E1')
+        eser2 = Service('E2.b')
+        eser3 = Service('E3.c')
+        group.add_inter_dep(target=ser1)
+        group.add_inter_dep(target=ser2)
+        group.add_dep(target=eser1, parent=False)
+        group.add_dep(target=eser2)
+        group.add_dep(target=eser3)
+        self.assertTrue(group.search('I1.a'))
+        self.assertTrue(group.search('E2.b'))
+        self.assertTrue(eser1.search('I1.a'))
+        self.assertTrue(eser1.search('E3.c'))
+        self.assertFalse(group.search('E0.d'))
+
+    def test_search_node_graph_with_dot_and_external(self):
+        """Test search node in a graph trough a ServiceGroup"""
+        group1 = ServiceGroup('GROUP1')
+        ser1 = Service('I1')
+        ser2 = Service('I2')
+        group2 = ServiceGroup('GROUP2')
+        eser1 = Service('I3')
+        eser2 = Service('I4')
+        eser3 = Service('I5')
+        group1.add_inter_dep(target=ser1)
+        group1.add_inter_dep(target=ser2)
+        group2.add_inter_dep(target=eser1)
+        group2.add_inter_dep(target=eser2)
+        group2.add_inter_dep(target=eser3)
+        self.assertTrue(group1.search('I1'))
+        self.assertTrue(group1.search('I2'))
+        self.assertTrue(group2.search('I3'))
+        self.assertTrue(group2.search('I4'))
+        self.assertTrue(group2.search('I5'))
+        self.assertFalse(group2.search('I1'))
+        self.assertFalse(group2.search('I2'))
+        self.assertFalse(group2.search('GROUP1.I1'))
+        self.assertFalse(group2.search('GROUP1.I2'))
+        group2.add_dep(group1, sgth=REQUIRE_WEAK)
+        self.assertTrue(group2.search('GROUP1.I1'))
+        self.assertTrue(group2.search('GROUP1.I2'))
+
     def test_add_dep_service_group(self):
         '''Test ability to add dependencies to a ServiceGroup'''
         ser_group = ServiceGroup('GROUP')


### PR DESCRIPTION
In the following patchset, I've implemented a way to specify a dependency between two services that belongs to different service groups.

To specify such a dependency, one can use a dotted syntax like :  `SERVICE_GROUP.SUBSERVICE_NAME`.

This will search, in the current dependency tree, a service group named `SERVICE_GROUP` which have a subservice named `SUBSERVICE_NAME`. If such a service exists, it is used as the dependent service. If not, regular dependency processing will proceed.

This allows a new kind of configuration structure where different service groups implements complete sub-systems management (Interconnect, Filesystems, ...) and dependencies are built between sub-service : 
  `filesystem.mount` may requires `interconnect.status` for example