### PR TITLE
Cli.py: replace isAlive() by is_alive() calls

### DIFF
--- a/lib/MilkCheck/UI/Cli.py
+++ b/lib/MilkCheck/UI/Cli.py
@@ -452,7 +452,7 @@ class InteractiveThread(threading.Thread):
 
     def join(self, timeout=None):
         '''Only join if thread is alive'''
-        if self.isAlive():
+        if self.is_alive():
             threading.Thread.join(self, timeout)
 
     def quit(self):


### PR DESCRIPTION
Since python 3.9 the camelcase function isAlive() ha been removed[1].
The call is present since python 2.7, we can safely remove it[2].

[1] https://github.com/python/cpython/pull/15225
[2] https://docs.python.org/2.7/library/threading.html