### PR TITLE
Fix interdeps nested

### DIFF
--- a/tests/MilkCheckTests/EngineTests/ActionTest.py
+++ b/tests/MilkCheckTests/EngineTests/ActionTest.py
@@ -53,7 +53,7 @@ class ActionTest(TestCase):
         dep = Service('dep')
         dep.add_action(Action('start', command='/bin/false'))
         # A service running on empty nodeset...
-        svc = Service('foo', target='@NOTEXIST')
+        svc = Service('foo', target='')
         # ... with an action overloading the empty nodeset
         svc.add_action(Action('start', target=HOSTNAME, command=':'))
 

--- a/tests/MilkCheckTests/EngineTests/BaseEntityTest.py
+++ b/tests/MilkCheckTests/EngineTests/BaseEntityTest.py
@@ -281,7 +281,7 @@ class BaseEntityTest(unittest.TestCase):
         '''
         ent1 = BaseEntity(name='parent')
         ent1.desc = "foo"
-        ent2 = BaseEntity(name='child', target="@none")
+        ent2 = BaseEntity(name='child', target="")
         ent2.desc = ""
         ent2.inherits_from(ent1)
         self.assertEqual(ent2.target, NodeSet())

--- a/tests/MilkCheckTests/EngineTests/ServiceGroupTest.py
+++ b/tests/MilkCheckTests/EngineTests/ServiceGroupTest.py
@@ -1151,29 +1151,30 @@ class ServiceGroupFromDictTest(TestCase):
         sergrp.fromdict({
             'services': {
                 'subgroupA': {
+                    'desc': 'I am a first group',
                     'services': {
                         'svcA':
                             {'actions':
                                 {
                                     'act1': {'cmd': '/bin/true'},
                                 },
-                                'desc': 'I am the subservice $NAME'
+                                'desc': 'I am the subservice %NAME'
                             },
                         'subsubgrpA': {
                             'services': {
                                 'depA': {
-                                    #'require': ['subgroupB.svcA'],
                                     'actions':
                                         {
                                             'act1': {'cmd': '/bin/true'},
                                         },
-                                    'desc': 'I am the subservice $NAME'
+                                    'desc': 'I am the subservice %NAME'
                                 },
                             },
                         },
                     },
                 },
                 'subgroupB': {
+                    'desc': 'I am another group',
                     'services': {
                         'svcA': {
                             'require': ['subgroupA.subsubgrpA.depA'],
@@ -1181,14 +1182,12 @@ class ServiceGroupFromDictTest(TestCase):
                                 {
                                     'act1': {'cmd': '/bin/true'}
                                 },
-                            'desc': 'I am the subservice $NAME'
+                            'desc': 'I am the subservice %NAME'
                         },
                     },
                 },
 
             },
-            'desc': 'I am a first group',
-            'target': 'localhost',
         })
 
         self.assertTrue(sergrp.has_subservice('subgroupA'))
@@ -1207,13 +1206,14 @@ class ServiceGroupFromDictTest(TestCase):
         sergrp.fromdict(
             {'services': {
                 'subgroupA': {
+                    'desc': 'I am a first group',
                     'services': {
                         'svcA':
                             {'actions':
                                 {
                                     'act1,act2': {'cmd': '/bin/true'},
                                 },
-                                'desc': 'I am the subservice $NAME'
+                                'desc': 'I am the subservice %NAME'
                             },
                         'svcB':
                             {'require': ['svcA'],
@@ -1222,11 +1222,12 @@ class ServiceGroupFromDictTest(TestCase):
                                      'act1': {'cmd': '/bin/true'},
                                      'act2': {'cmd': '/bin/false'},
                                  },
-                             'desc': 'I am the subservice $NAME'
+                             'desc': 'I am the subservice %NAME'
                              }
                     }
                 },
                 'subgroupB': {
+                    'desc': 'I am another group',
                     'services': {
                         'svcA': {
                             'require': ['subgroupA.svcB'],
@@ -1234,21 +1235,19 @@ class ServiceGroupFromDictTest(TestCase):
                                 {
                                     'act1,act2': {'cmd': '/bin/true'}
                                 },
-                            'desc': 'I am the subservice $NAME'
+                            'desc': 'I am the subservice %NAME'
                         },
                         'svcB': {
                             'actions':
                                 {
                                     'act1,act2': {'cmd': '/bin/true'}
                                 },
-                            'desc': 'I am the subservice $NAME'
+                            'desc': 'I am the subservice %NAME'
                         }
                     }
                 }
 
                 },
-            'desc': 'I am a first group',
-            'target': 'localhost',
         })
 
         self.assertTrue(sergrp.has_subservice('subgroupA'))
@@ -1270,13 +1269,14 @@ class ServiceGroupFromDictTest(TestCase):
         self.assertRaises(UnknownDependencyError, sergrp.fromdict, {
             'services': {
                 'subgroupA': {
+                    'desc': 'I am a first group',
                     'services': {
                         'svcA':
                             {'actions':
                                 {
                                     'act1,act2': {'cmd': '/bin/true'},
                                 },
-                                'desc': 'I am the subservice $NAME'
+                                'desc': 'I am the subservice %NAME'
                             },
                         'svcB':
                             {'require': ['svcA'],
@@ -1285,11 +1285,12 @@ class ServiceGroupFromDictTest(TestCase):
                                      'act1': {'cmd': '/bin/true'},
                                      'act2': {'cmd': '/bin/false'},
                                  },
-                             'desc': 'I am the subservice $NAME'
+                             'desc': 'I am the subservice %NAME'
                              }
                     }
                 },
                 'subgroupB': {
+                    'desc': 'I am another group',
                     'services': {
                         'svcA': {
                             'require': ['subgroupA.svcB'],
@@ -1297,21 +1298,19 @@ class ServiceGroupFromDictTest(TestCase):
                                 {
                                     'act1,act2': {'cmd': '/bin/true'}
                                 },
-                            'desc': 'I am the subservice $NAME'
+                            'desc': 'I am the subservice %NAME'
                         },
                         'svcB': {
                             'actions':
                                 {
                                     'act1,act2': {'cmd': '/bin/true'}
                                 },
-                            'desc': 'I am the subservice $NAME'
+                            'desc': 'I am the subservice %NAME'
                         }
                     }
                 }
 
             },
-            'desc': 'I am a first group',
-            'target': 'localhost',
         })
 
     def test_inter_subservice_deps_dict_nested(self):
@@ -1326,19 +1325,20 @@ class ServiceGroupFromDictTest(TestCase):
                                 {
                                     'act1,act2': {'cmd': '/bin/true'},
                                 },
-                                'desc': 'I am the subservice $NAME'
+                                'desc': 'I am the subservice %NAME'
                             },
                         'svcB':
-                            {'require': ['svcA'],
+                            {
                              'services': {
                                  'subsvc': {
+                                     'require': ['subgroupA.svcA'],
                                      'actions':{
                                          'act1': {'cmd': '/bin/true'},
                                          'act2': {'cmd': '/bin/false'},
                                      }
                                  }
                              },
-                             'desc': 'I am the subservice $NAME'
+                             'desc': 'I am the subservice %NAME'
                              }
                     }
                 },
@@ -1348,23 +1348,21 @@ class ServiceGroupFromDictTest(TestCase):
                             'require': ['svcB.subsvc'],
                             'actions':
                                 {
-                                    'act1,act2': {'cmd': '/bin/true'}
+                                    'act1,act2': {'cmd': '/bin/true'},
                                 },
-                            'desc': 'I am the subservice $NAME'
+                            'desc': 'I am the subservice %NAME'
                         },
                         'svcB': {
                             'actions':
                                 {
-                                    'act1,act2': {'cmd': '/bin/true'}
+                                    'act1,act2': {'cmd': '/bin/true'},
                                 },
-                            'desc': 'I am the subservice $NAME'
+                            'desc': 'I am the subservice %NAME'
                         }
                     }
                 }
 
                 },
-            'desc': 'I am a first group',
-            'target': 'localhost',
         })
 
         self.assertTrue(sergrp.has_subservice('subgroupA'))

--- a/tests/MilkCheckTests/EngineTests/ServiceGroupTest.py
+++ b/tests/MilkCheckTests/EngineTests/ServiceGroupTest.py
@@ -565,9 +565,9 @@ class ServiceGroupTest(TestCase):
         """A group with only SKIPPED services should be SKIPPED"""
         grp = ServiceGroup('group')
         svc1 = Service('svc1')
-        svc1.add_action(Action('start', target="@NOTHING", command=':'))
+        svc1.add_action(Action('start', target="", command=':'))
         svc2 = Service('svc2')
-        svc2.add_action(Action('start', target="@NOTHING", command=':'))
+        svc2.add_action(Action('start', target="", command=':'))
         grp.add_inter_dep(target=svc1)
         grp.add_inter_dep(target=svc2)
         grp.run('start')
@@ -579,9 +579,9 @@ class ServiceGroupTest(TestCase):
         svc.add_action(Action('start', command='/bin/false'))
         grp = ServiceGroup('group')
         svc1 = Service('svc1')
-        svc1.add_action(Action('start', target="@NOTHING", command=':'))
+        svc1.add_action(Action('start', target="", command=':'))
         svc2 = Service('svc2')
-        svc2.add_action(Action('start', target="@NOTHING", command=':'))
+        svc2.add_action(Action('start', target="", command=':'))
         grp.add_inter_dep(target=svc1)
         grp.add_inter_dep(target=svc2)
         grp.add_dep(svc, sgth=REQUIRE)
@@ -1127,7 +1127,7 @@ class ServiceGroupFromDictTest(TestCase):
                     'actions': {
                         'start': {'cmd': '/bin/True'},
                     },
-                  'target': '@none',
+                  'target': '',
                 }}})
         self.assertEqual(sergrp._subservices['svc1'].target, NodeSet())
 


### PR DESCRIPTION
A lot of typos was introduced in ServiceGroupTests.

This PR fixes #70, clean these typos and remove usage of nodesets groups in all tests.